### PR TITLE
Fix role update permission sync

### DIFF
--- a/app/Modules/users/Services/RoleServiceStore.php
+++ b/app/Modules/users/Services/RoleServiceStore.php
@@ -66,12 +66,13 @@ class RoleServiceStore extends Service implements ServiceStore
      */
     public function update($id, Request $request)
     {
-            $data = $request->only($this->model->getFillable());
-            $role = $this->roleRepositoryStore->update($id, $data);
-            if ($role)
-                $roleObject = $this->roleRepositoryShow->find($id);
+        $data = $request->only($this->model->getFillable());
+        $role = $this->roleRepositoryStore->update($id, $data);
+        if ($role) {
+            $roleObject = $this->roleRepositoryShow->find($id);
             $this->roleRepositoryStore->syncPermissions($request->selected, $roleObject);
-            return $role;
+        }
+        return $role;
 //
     }
 


### PR DESCRIPTION
## Summary
- avoid uninitialized variable when updating role permissions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a613792388323a31117e494177302